### PR TITLE
use store path

### DIFF
--- a/cmd/routing-api/testrunner/db.go
+++ b/cmd/routing-api/testrunner/db.go
@@ -240,5 +240,6 @@ func (a *sqliteAllocator) minConfig() *config.SqlDB {
 	return &config.SqlDB{
 		Type:   "sqlite3",
 		Schema: a.schemaName,
+		StorePath: ".",
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type SqlDB struct {
 	MaxIdleConns           int    `yaml:"max_idle_connections"`
 	MaxOpenConns           int    `yaml:"max_open_connections"`
 	ConnMaxLifetime        int    `yaml:"connections_max_lifetime_seconds"`
+	StorePath              string `yaml:"store_path"`
 }
 
 type APIConfig struct {

--- a/db/db_sql.go
+++ b/db/db_sql.go
@@ -621,8 +621,8 @@ func ConnectionString(cfg *config.SqlDB) (string, error) {
 	var connectionString string
 	switch cfg.Type {
 	case "sqlite3":
-		dbFile := SqlLiteDatabaseFile(cfg)
-		return fmt.Sprintf("file:%s", dbFile), nil
+		dbFileFull := fmt.Sprintf("file:%s?mode=rwc", SqlLiteDatabaseFile(cfg))
+		return dbFileFull, nil
 
 	case "mysql":
 		connStringBuilder := &MySQLConnectionStringBuilder{MySQLAdapter: &MySQLAdapter{}}
@@ -663,5 +663,6 @@ func ConnectionString(cfg *config.SqlDB) (string, error) {
 }
 
 func SqlLiteDatabaseFile(cfg *config.SqlDB) string {
-	return fmt.Sprintf("%s.db", cfg.Schema)
+	filename := fmt.Sprintf("%s/%s.db", cfg.StorePath, cfg.Schema)
+	return filename
 }


### PR DESCRIPTION
bpm does not allow access to the peristent disk by default.
this uses that persistent disk when sqlite is selected

[#175661519]